### PR TITLE
SEM-1401-calendar-component

### DIFF
--- a/dev/js/Calendar.js
+++ b/dev/js/Calendar.js
@@ -60,8 +60,17 @@
 
     this.calendarHTML(this.type);
 
+    $('.daterange').attr('aria-live', 'polite');
+
     $('.dr-presets', this.element).click(function() {
       self.presetToggle();
+    });
+
+    $('.dr-presets', this.element).keypress(function(event) {
+      var keycode = event.keyCode || event.which;
+      if(keycode == '13' || keycode == '32') {
+        self.presetToggle();
+      }
     });
 
     $('.dr-list-item', this.element).click(function() {
@@ -74,6 +83,21 @@
       self.calendarSetDates();
       self.presetToggle();
       self.calendarSaveDates();
+    });
+
+    $('.dr-list-item', this.element).keypress(function(event) {
+      var keycode = event.keyCode || event.which;
+      if(keycode == '13' || keycode == '32') {
+        var start = $('.dr-item-aside', this).data('start');
+        var end = $('.dr-item-aside', this).data('end');
+
+        self.start_date = self.calendarCheckDate(start);
+        self.end_date = self.calendarCheckDate(end);
+
+        self.calendarSetDates();
+        self.presetToggle();
+        self.calendarSaveDates();
+      }
     });
 
     $('.dr-date', this.element).on({
@@ -283,7 +307,7 @@
 
       var startISO = moment(d.start).toISOString();
       var endISO = moment(d.end).toISOString();
-      var string = moment(d.start).format(self.format.preset) +' &ndash; '+ moment(d.end).format(self.format.preset);
+      var string = moment(d.start).format(self.format.preset) +' &ndash; <span class="sr-only">'+ moment(d.end).format(self.format.preset);
 
       if ($('.dr-preset-list', self.element).length) {
         var item = $('.dr-preset-list .dr-list-item:nth-of-type('+ (i + 1) +') .dr-item-aside', self.element);
@@ -291,9 +315,9 @@
         item.data('end', endISO);
         item.html(string);
       } else {
-        ul_presets.append('<li class="dr-list-item">'+ d.label +
+        ul_presets.append('<li><div class="dr-list-item" role="button" tabindex="0">'+ d.label +
           '<span class="dr-item-aside" data-start="'+ startISO +'" data-end="'+ endISO +'">'+ string +'</span>'+
-        '</li>');
+        '</div></li>');
       }
     });
 
@@ -688,7 +712,7 @@
           '<div class="dr-date dr-date-end" contenteditable>'+ moment(this.end_date).format(this.format.input) +'</div>' +
         '</div>' +
 
-        (this.presets ? '<div class="dr-presets">' +
+        (this.presets ? '<div class="dr-presets" role="button" tabindex="0" aria-label="Open more options">' +
           '<span class="dr-preset-bar"></span>' +
           '<span class="dr-preset-bar"></span>' +
           '<span class="dr-preset-bar"></span>' +

--- a/dev/js/Calendar.js
+++ b/dev/js/Calendar.js
@@ -66,9 +66,10 @@
       self.presetToggle();
     });
 
-    $('.dr-presets', this.element).keypress(function(event) {
-      var keycode = event.keyCode || event.which;
-      if(keycode == '13' || keycode == '32') {
+    $('.dr-presets', this.element).keydown(function(e) {
+      let key = e.key,
+          keyCode = e.keyCode;
+      if (key && 'Enter' === key || key && 'Space' === key || keyCode && 13 === keyCode || keyCode && 32 === keyCode) {
         self.presetToggle();
       }
     });
@@ -85,9 +86,10 @@
       self.calendarSaveDates();
     });
 
-    $('.dr-list-item', this.element).keypress(function(event) {
-      var keycode = event.keyCode || event.which;
-      if(keycode == '13' || keycode == '32') {
+    $('.dr-list-item', this.element).keydown(function(e) {
+      let key = e.key,
+          keyCode = e.keyCode;
+      if (key && 'Enter' === key || key && 'Space' === key || keyCode && 13 === keyCode || keyCode && 32 === keyCode) {
         var start = $('.dr-item-aside', this).data('start');
         var end = $('.dr-item-aside', this).data('end');
 

--- a/dev/js/Calendar.js
+++ b/dev/js/Calendar.js
@@ -307,7 +307,7 @@
 
       var startISO = moment(d.start).toISOString();
       var endISO = moment(d.end).toISOString();
-      var string = moment(d.start).format(self.format.preset) +' &ndash; <span class="sr-only">'+ moment(d.end).format(self.format.preset);
+      var string = moment(d.start).format(self.format.preset) +' &ndash; <span class="sr-only">to</span>'+ moment(d.end).format(self.format.preset);
 
       if ($('.dr-preset-list', self.element).length) {
         var item = $('.dr-preset-list .dr-list-item:nth-of-type('+ (i + 1) +') .dr-item-aside', self.element);

--- a/dev/js/Calendar.js
+++ b/dev/js/Calendar.js
@@ -69,7 +69,7 @@
     $('.dr-presets', this.element).keydown(function(e) {
       let key = e.key,
           keyCode = e.keyCode;
-      if (key && 'Enter' === key || ' ' === key || keyCode && 13 === keyCode || 32 === keyCode) {
+      if (key && ('Enter' === key || ' ' === key) || keyCode && (13 === keyCode || 32 === keyCode)) {
         self.presetToggle();
       }
     });
@@ -89,7 +89,7 @@
     $('.dr-list-item', this.element).keydown(function(e) {
       let key = e.key,
           keyCode = e.keyCode;
-      if (key && 'Enter' === key || ' ' === key || keyCode && 13 === keyCode || 32 === keyCode) {
+      if (key && ('Enter' === key || ' ' === key) || keyCode && (13 === keyCode || 32 === keyCode)) {
         var start = $('.dr-item-aside', this).data('start');
         var end = $('.dr-item-aside', this).data('end');
 

--- a/dev/js/Calendar.js
+++ b/dev/js/Calendar.js
@@ -69,7 +69,7 @@
     $('.dr-presets', this.element).keydown(function(e) {
       let key = e.key,
           keyCode = e.keyCode;
-      if (key && 'Enter' === key || key && 'Space' === key || keyCode && 13 === keyCode || keyCode && 32 === keyCode) {
+      if (key && 'Enter' === key || ' ' === key || keyCode && 13 === keyCode || 32 === keyCode) {
         self.presetToggle();
       }
     });
@@ -89,7 +89,7 @@
     $('.dr-list-item', this.element).keydown(function(e) {
       let key = e.key,
           keyCode = e.keyCode;
-      if (key && 'Enter' === key || key && 'Space' === key || keyCode && 13 === keyCode || keyCode && 32 === keyCode) {
+      if (key && 'Enter' === key || ' ' === key || keyCode && 13 === keyCode || 32 === keyCode) {
         var start = $('.dr-item-aside', this).data('start');
         var end = $('.dr-item-aside', this).data('end');
 

--- a/dev/js/Calendar.js
+++ b/dev/js/Calendar.js
@@ -741,7 +741,7 @@
 
     return this.element.append('<div class="dr-input">' +
       '<div class="dr-dates">' +
-        '<div class="dr-date" contenteditable placeholder="'+ this.placeholder +'">'+ (this.settings.current_date ? moment(this.current_date).format(this.format.input) : '') +'</div>' +
+        '<div class="dr-date" contenteditable aria-label="Select a date in MM/DD/YYYY format" placeholder="'+ this.placeholder +'">'+ (this.settings.current_date ? moment(this.current_date).format(this.format.input) : '') +'</div>' +
       '</div>' +
     '</div>' +
 

--- a/dev/sass/_daterange.scss
+++ b/dev/sass/_daterange.scss
@@ -309,3 +309,16 @@
     }
   }
 }
+
+// Hidden visually but available for screenreader users
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}


### PR DESCRIPTION
[Calendar component](https://thinkific.atlassian.net/browse/SEM-1401)

- Added `aria-live` so screenreaders would acknowledge changes
- Added some `aria-labels`
- Added `role="button"` and `tabindex` to the dropdown buttons that were missing.

**Example of navigating with keyboard:**
![Screen Recording 2021-01-05 at 02 11 38 PM](https://user-images.githubusercontent.com/14065121/103705586-26b84f80-4f60-11eb-93e2-93e6284ed549.gif)
